### PR TITLE
New gas and fee estimation logic

### DIFF
--- a/contracts/Frens.sol
+++ b/contracts/Frens.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.2;
+pragma solidity ^0.8.20;
 
 import '@openzeppelin/contracts/utils/cryptography/ECDSA.sol';
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
@@ -14,13 +14,20 @@ import "@opengsn/contracts/src/interfaces/IERC2771Recipient.sol";
 
 
 contract Frens is IERC721Receiver, IERC1155Receiver, ERC2771Recipient, Ownable {
-    uint256 public lockBlocks = 12; // 12 blocks
-    mapping(address => uint256) public gasLimits;
-    uint256 public defaultGasLimit = 21000;
-    uint256 public protocolFee = 0.0005 ether;
-    uint256 public profit = 0;
-    uint256 public minGasPrice = 0;
+    uint256 public lockBlocks = 100; // after 100 blocks the deposit sender can with their deposited tokens by them self
     address[] public whiteListTokens;
+    bool public allowReceivingERC721 = false;
+
+    // Gas & Fee configurations
+    uint256 public defaultGasLimit = 21000;
+    mapping(uint8 => uint256) public gasLimitPerContractType;
+    uint256 public baseGasFee = 0;
+    uint256 public priorityGasFee = 0;
+
+    uint256 public defaultProtocolFee = 0.0005 ether;
+    mapping(uint8 => uint256) public protocolFeePerContractType;
+    uint256 public protocolBalance = 0;
+    // ---------------------------------------- //
 
     struct deposit {
         address pubKey; // Key to lock the token
@@ -55,7 +62,8 @@ contract Frens is IERC721Receiver, IERC1155Receiver, ERC2771Recipient, Ownable {
 
     constructor(address forwarder) {
         _setTrustedForwarder(forwarder);
-        minGasPrice = tx.gasprice;
+        baseGasFee = block.basefee;
+        priorityGasFee = tx.gasprice - block.basefee;
     }
 
     function setTrustedForwarder(address _forwarder) external onlyOwner {
@@ -66,30 +74,8 @@ contract Frens is IERC721Receiver, IERC1155Receiver, ERC2771Recipient, Ownable {
         lockBlocks = _lockBlocks;
     }
 
-    function setGasLimit(address _token, uint256 _gasLimit) external onlyOwner {
-        gasLimits[_token] = _gasLimit;
-    }
-
-    function setDefaultGasLimit(uint256 _gasLimit) external onlyOwner {
-        defaultGasLimit = _gasLimit;
-    }
-
-    function setProtocolFee(uint256 _protocolFee) external onlyOwner {
-        protocolFee = _protocolFee;
-    }
-
-    function setMinGasPrice(uint256 _minGasPrice) external onlyOwner {
-        minGasPrice = _minGasPrice;
-    }
-
-    function estimateFee(address _token) public view returns(uint256) {
-        uint256 gasLimit = gasLimits[_token];
-        if (gasLimit == 0) {
-            gasLimit = defaultGasLimit;
-        }
-        uint256 gasPrice = minGasPrice > tx.gasprice? minGasPrice:tx.gasprice;
-        uint256 withdrawFee = (gasPrice * gasLimit);
-        return withdrawFee + protocolFee;
+    function toogleAllowReceivingERC721() external onlyOwner {
+        allowReceivingERC721 = !allowReceivingERC721;
     }
 
     function setWhiteListTokens(address[] memory _tokenAddress) external  onlyOwner {
@@ -108,6 +94,50 @@ contract Frens is IERC721Receiver, IERC1155Receiver, ERC2771Recipient, Ownable {
         return false;
     }
 
+    function setGasLimit(uint8 _contractType, uint256 _gasLimit) external onlyOwner {
+        require(_contractType < 4, "INVALID CONTRACT TYPE");
+        require(_gasLimit >= defaultGasLimit, "INVALID GAS LIMIT");
+        gasLimitPerContractType[_contractType] = _gasLimit;
+    }
+
+    function setBaseGasFee(uint256 _baseGasFee) external onlyOwner {
+        baseGasFee = _baseGasFee;
+    }
+
+    function setPriorityGasFee(uint256 _priorityGasFee) external onlyOwner {
+        priorityGasFee = _priorityGasFee;
+    }
+
+    function setProtocolFee(uint8 _contractType, uint256 _protocolFee) external onlyOwner {
+        require(_contractType < 4, "INVALID CONTRACT TYPE");
+        require(_protocolFee > 0, "INVALID PROCOL FEE");
+        protocolFeePerContractType[_contractType] = _protocolFee;
+    }
+
+    function estimateGasFeeForWithdrawing(uint8 _contractType) public view returns(uint256) {
+        uint256 gasLimit = gasLimitPerContractType[_contractType];
+        if (gasLimit == 0) {
+            gasLimit = defaultGasLimit;
+        }
+        uint256 gasPrice = baseGasFee + priorityGasFee;
+        if (gasPrice < tx.gasprice) {
+            gasPrice = tx.gasprice;
+        }
+        return gasLimit * gasPrice;
+    }
+
+    function estimateProtocolFee(uint8 _contractType) public view returns(uint256) {
+        uint256 fee = protocolFeePerContractType[_contractType];
+        if (fee == 0) {
+            return defaultProtocolFee;
+        }
+        return fee;
+    }
+
+    function estimateFee(uint8 _contractType) public view returns(uint256) {
+        return estimateProtocolFee(_contractType) + estimateGasFeeForWithdrawing(_contractType);
+    }
+
     function makeDeposit(
         address _tokenAddress,
         uint8 _contractType,
@@ -118,13 +148,13 @@ contract Frens is IERC721Receiver, IERC1155Receiver, ERC2771Recipient, Ownable {
         require(_contractType < 4, "INVALID CONTRACT TYPE");
         require(isAllowDepositToken(_tokenAddress), "TokenAddress is not allowed");
 
-        uint256 fee = estimateFee(_tokenAddress);
+        uint256 fee = estimateFee(_contractType);
         require(msg.value >= fee, "NOT ENOUGH PROTOCOL FEE");
         if (_contractType == 0) {
             _amount = msg.value - fee;
-            profit += fee;
+            protocolBalance += fee;
         } else {
-            profit += msg.value;
+            protocolBalance += msg.value;
         }
         return _makeDeposit(_tokenAddress, _contractType, _amount, _tokenId, _pubKey);
     }
@@ -230,14 +260,14 @@ contract Frens is IERC721Receiver, IERC1155Receiver, ERC2771Recipient, Ownable {
         require(_contractType < 2, "INVALID CONTRACT TYPE");
         require(isAllowDepositToken(_tokenAddress), "TokenAddress is not allowed");
 
-        uint256 fee = _pubKeys.length * estimateFee(_tokenAddress);
+        uint256 fee = _pubKeys.length * estimateFee(_contractType);
         require(msg.value >= fee, "NOT ENOUGH PROTOCOL FEE");
         if (_contractType == 0) {
             _amount = msg.value - fee;
             require(_amount > 0, "CAN NOT SENT ZERO TOKEN");
-            profit += fee;
+            protocolBalance += fee;
         } else {
-            profit += msg.value;
+            protocolBalance += msg.value;
         }
 
         uint256 amountPerDeposit = _amount/_pubKeys.length;
@@ -554,10 +584,10 @@ contract Frens is IERC721Receiver, IERC1155Receiver, ERC2771Recipient, Ownable {
 
 
     function withdrawProfit(address payable payee) external onlyOwner {
-        require(profit > 0, "No profit");
-        payee.transfer(profit);
-        profit = 0;
-        emit WithdrawnProfit(payee, profit);
+        require(protocolBalance > 0, "No profit");
+        payee.transfer(protocolBalance);
+        protocolBalance = 0;
+        emit WithdrawnProfit(payee, protocolBalance);
     }
 
     /**

--- a/contracts/Frens.sol
+++ b/contracts/Frens.sol
@@ -16,7 +16,7 @@ import "@opengsn/contracts/src/interfaces/IERC2771Recipient.sol";
 contract Frens is IERC721Receiver, IERC1155Receiver, ERC2771Recipient, Ownable {
     uint256 public lockBlocks = 100; // after 100 blocks the deposit sender can with their deposited tokens by them self
     address[] public whiteListTokens;
-    bool public allowReceivingERC721 = false;
+    bool public allowReceivingNFT = false;
 
     // Gas & Fee configurations
     uint256 public constant minGasLimit = 21000 wei;
@@ -80,8 +80,8 @@ contract Frens is IERC721Receiver, IERC1155Receiver, ERC2771Recipient, Ownable {
         lockBlocks = _lockBlocks;
     }
 
-    function toogleAllowReceivingERC721() external onlyOwner {
-        allowReceivingERC721 = !allowReceivingERC721;
+    function toogleAllowReceivingNFT() external onlyOwner {
+        allowReceivingNFT = !allowReceivingNFT;
     }
 
     function setWhiteListTokens(address[] memory _tokenAddress) external  onlyOwner {
@@ -305,6 +305,7 @@ contract Frens is IERC721Receiver, IERC1155Receiver, ERC2771Recipient, Ownable {
             // if data is not 20 bytes, revert (don't want to accept and lock up tokens!)
             revert("INVALID CALLDATA");
         }
+        require(allowReceivingNFT, "NOT ALLOW RECEING ERC721");
 
         // get the params from calldata and make a deposit
         address _tokenAddress = _msgSender();
@@ -362,7 +363,8 @@ contract Frens is IERC721Receiver, IERC1155Receiver, ERC2771Recipient, Ownable {
         } else if (_data.length != 20) {
             // if data is not 20 bytes, revert (don't want to accept and lock up tokens!)
             revert("INVALID CALLDATA");
-        }
+        } 
+        require(allowReceivingNFT, "NOT ALLOW RECEING ERC1155");
 
         // get the params from calldata and make a deposit
         address _tokenAddress = _msgSender();
@@ -416,7 +418,7 @@ contract Frens is IERC721Receiver, IERC1155Receiver, ERC2771Recipient, Ownable {
             // dont accept if data is not 20 bytes per token
             revert("INVALID CALLDATA");
         }
-
+        require(allowReceivingNFT, "NOT ALLOW RECEING ERC1155");
         // get the params from calldata and make a deposit
         address _tokenAddress = _msgSender();
         uint8 _contractType = 4;

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -1,5 +1,16 @@
 require("@nomicfoundation/hardhat-toolbox");
 
 module.exports = {
-  solidity: "0.8.2",
+  solidity: "0.8.20",
+  settings: {
+    viaIR: true,
+    optimizer: {
+      enabled: true,
+      details: {
+        yulDetails: {
+          optimizerSteps: "u",
+        },
+      },
+    },
+  },
 };

--- a/test/Frens.js
+++ b/test/Frens.js
@@ -31,14 +31,14 @@ describe("Frens", function () {
 
   it("Should set the right lockBlocks", async function () {
     const { frens } = await loadFixture(deployFrens);
-    expect(await frens.lockBlocks()).to.equal(12);
+    expect(await frens.lockBlocks()).to.equal(100);
     await frens.setLockBlocks(13);
     expect(await frens.lockBlocks()).to.equal(13);
   });
 
   it("Should set the right gasLimits", async function () {
     const { frens } = await loadFixture(deployFrens);
-    expect(await frens.gasLimitPerContractType(0)).to.equal(0);
+    expect(await frens.gasLimitPerContractType(0)).to.equal(21000);
     await frens.setGasLimit(ZERO_ADDRESS, 30000);
     expect(await frens.gasLimitPerContractType(0)).to.equal(30000);
   });
@@ -46,7 +46,7 @@ describe("Frens", function () {
   it("Should set the right protocol fee", async function () {
     const { frens } = await loadFixture(deployFrens);
     expect(await frens.estimateProtocolFee(0)).to.equal(ethers.parseEther("0.0005", "ether"));
-    const newEther = ethers.parseEther("0.0001", "ether")
+    const newEther = ethers.parseEther("0.01", "ether")
     await frens.setProtocolFee(0, newEther);
     expect(await frens.estimateProtocolFee(0)).to.equal(newEther);
   });

--- a/test/Frens.js
+++ b/test/Frens.js
@@ -38,40 +38,39 @@ describe("Frens", function () {
 
   it("Should set the right gasLimits", async function () {
     const { frens } = await loadFixture(deployFrens);
-    expect(await frens.gasLimits(ZERO_ADDRESS)).to.equal(0);
+    expect(await frens.gasLimitPerContractType(0)).to.equal(0);
     await frens.setGasLimit(ZERO_ADDRESS, 30000);
-    expect(await frens.gasLimits(ZERO_ADDRESS)).to.equal(30000);
-  });
-
-  it("Should set the right default gas limit", async function () {
-    const { frens } = await loadFixture(deployFrens);
-    expect(await frens.defaultGasLimit()).to.equal(21000);
-    await frens.setDefaultGasLimit(30000);
-    expect(await frens.defaultGasLimit()).to.equal(30000);
+    expect(await frens.gasLimitPerContractType(0)).to.equal(30000);
   });
 
   it("Should set the right protocol fee", async function () {
     const { frens } = await loadFixture(deployFrens);
-    expect(await frens.protocolFee()).to.equal(ethers.parseEther("0.0005", "ether"));
+    expect(await frens.estimateProtocolFee(0)).to.equal(ethers.parseEther("0.0005", "ether"));
     const newEther = ethers.parseEther("0.0001", "ether")
-    await frens.setProtocolFee(newEther);
-    expect(await frens.protocolFee()).to.equal(newEther);
+    await frens.setProtocolFee(0, newEther);
+    expect(await frens.estimateProtocolFee(0)).to.equal(newEther);
   });
 
-  it("Should set the right min gas price", async function () {
+  it("Should set the right baseGasFee", async function () {
     const { frens } = await loadFixture(deployFrens);
-    expect(await frens.protocolFee()).to.greaterThan(0);
-    await frens.setMinGasPrice(10000);
-    expect(await frens.minGasPrice()).to.equal(10000);
+    expect(await frens.baseGasFee()).to.greaterThan(0);
+    await frens.setBaseGasFee(10000);
+    expect(await frens.baseGasFee()).to.equal(10000);
+  });
+
+  it("Should set the right priorityGasFee", async function () {
+    const { frens } = await loadFixture(deployFrens);
+    expect(await frens.priorityGasFee()).to.greaterThan(0);
+    await frens.setPriorityGasFee(10000);
+    expect(await frens.priorityGasFee()).to.equal(10000);
   });
 
   it("Should estimate right fee", async function () {
     const { frens } = await loadFixture(deployFrens);
 
-    const gasLimit = await frens.defaultGasLimit();
-    const gasPrice = await frens.minGasPrice();
-    const protocolFee = await frens.protocolFee();
-    expect(await frens.estimateFee(ZERO_ADDRESS)).to.equal(protocolFee + (gasLimit*gasPrice));
+    const gasFee = await frens.estimateGasFeeForWithdrawing(0);
+    const protocolFee = await frens.estimateProtocolFee(0);
+    expect(await frens.estimateFee(0)).to.equal(protocolFee + gasFee);
   });
 
   it("Should update white list tokens", async function () {
@@ -128,7 +127,7 @@ describe("Frens", function () {
     const tokenId = 0
     const pubKey20 = "0x0000000000000000000000000000000000000000"
 
-    const fee = await frens.estimateFee(erc20.target);
+    const fee = await frens.estimateFee(1);
     expect(await frens.getDepositCount()).to.equal(0);
 
 

--- a/test/Frens.js
+++ b/test/Frens.js
@@ -73,6 +73,13 @@ describe("Frens", function () {
     expect(await frens.estimateFee(0)).to.equal(protocolFee + gasFee);
   });
 
+  it("Should toogleAllowReceivingNFT ok", async function () {
+    const { frens } = await loadFixture(deployFrens);
+    expect( await frens.allowReceivingNFT()).to.equal(false);
+    await frens.toogleAllowReceivingNFT();
+    expect( await frens.allowReceivingNFT()).to.equal(true);
+  });
+
   it("Should update white list tokens", async function () {
     const { frens } = await loadFixture(deployFrens);
     await expect(frens.whiteListTokens(0)).to.be.revertedWithoutReason();


### PR DESCRIPTION
#### New mechanims to estimate total fee that user have to pay: 

`WithdrawGasFee = (BaseGasFee + PriorityGasFee) * GasLimit`
`ProtocolFee = 0.0005 ether` fixed value.
`TotalFee = WithdrawGasFee + ProtocolFee`.

#### Modify contract functions:
- Add functions to support modify BaseGasFee, PriorityGasFee and GasLimit for each contractType.
- Add functions to support modify ProtocolFee for each contractType.
- Add flag to support enable/disable Receiving NFT from blockchain.
- Update estimateFee function to adapt new changes.

